### PR TITLE
Don't print headers or body when print time

### DIFF
--- a/httpie/output/streams.py
+++ b/httpie/output/streams.py
@@ -92,6 +92,8 @@ def build_output_stream(args, env, request, response):
         output.append(Stream(
             msg=HTTPResponse(response),
             with_time=resp_t,
+            with_headers=False,
+            with_body=False,
             elapsed_time=response.elapsed))
 
     if env.stdout_isatty and resp_b:


### PR DESCRIPTION
I think this fixes the problem you mentioned in https://github.com/jakubroztocil/httpie/pull/286

>  the body gets printed by default (even with JUST "-p t"). I wasn't able to track down why that was happening.

```
[marca@marca-mac2 httpie]$ http -p t www.google.com
0:0:0.535

[marca@marca-mac2 httpie]$ http -p th www.google.com
HTTP/1.1 200 OK
Accept-Ranges: none
Alternate-Protocol: 80:quic,p=0.08
Cache-Control: private, max-age=0
Content-Type: text/html; charset=ISO-8859-1
Date: Mon, 16 Feb 2015 08:18:09 GMT
Expires: -1
P3P: CP="This is not a P3P policy! See http://www.google.com/support/accounts/bin/answer.py?hl=en&answer=151657 for more info."
Server: gws
Set-Cookie: PREF=ID=305bc6dd38e9c191:FF=0:TM=1424074689:LM=1424074689:S=NON53U6jlJFF-jTG; expires=Wed, 15-Feb-2017 08:18:09 GMT; path=/; domain=.google.com
Set-Cookie: NID=67=bttvH7xOqK1W4Yxm_ZIt0djqEc-PGTUoGLhYAUD1BYZfx8gjwBaXKIe0iMGIvCLjRl0ptM5HU-r8SFoS19koEYbcpZruhyTSW2iP3HZTnD-tNeGJXVGT8z6KALHeMEWF; expires=Tue, 18-Aug-2015 08:18:09 GMT; path=/; domain=.google.com; HttpOnly
Transfer-Encoding: chunked
Vary: Accept-Encoding
X-Frame-Options: SAMEORIGIN
X-XSS-Protection: 1; mode=block

0:0:0.97
```
